### PR TITLE
httpclient.HTTPSConnection 의 연결 끊김 문제.

### DIFF
--- a/closedown/closedown.py
+++ b/closedown/closedown.py
@@ -43,7 +43,7 @@ class Singleton(type):
         return cls._instances[cls]
 
 class CloseDown(__with_metaclass(Singleton,object)):
-    def __init__(self,LinkID,SecretKey,TimeOut = 15):
+    def __init__(self,LinkID,SecretKey,TimeOut = 60):
         """ 생성자.
             args
                 LinkID : 링크허브에서 발급받은 LinkID


### PR DESCRIPTION
/Time API 를 미리 호출하여 해당 연결이 유효한지 판단한 후,

연결이 더이상 유효하지 않다면, 연결을 새로 생성한다.

또한 TimeOut 을 두어 연결이 성립된지 15초(현재 기본값)이 지났다면

무조껀 연결을 재 생성하도록 한다.

(/Time API 호출보다 서버의 오버헤드가 더 적을 것으로 예상된다.)
